### PR TITLE
Path shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Samples:
 * `log_analyzer -file log/production.log -sort count -filter view`
 * `log_analyzer -file log/production.log -sort count -filter partial`
 * `log_analyzer -file log/production.log -sort time -filter P`
+* `log_analyzer -file log/production.log --short-paths`
 * `log_analyzer --help`
 
 **Based on results you can get an idea what to optimize. For example optimizing most often rendering view could give huge benefit. Now with this tool you can find out what are the numbers.**

--- a/bin/log_analyzer
+++ b/bin/log_analyzer
@@ -23,6 +23,10 @@ parser = OptionParser.new do |opts|
     options[:filter] = v
   end
 
+  opts.on("-sp", "--short-paths", "Shrink long paths") do |v|
+    options[:short_paths] = v
+  end
+
   opts.on('-h', '--help', 'Displays Help') do
     puts opts
     exit
@@ -31,9 +35,10 @@ end
 
 parser.parse!
 
-options[:file]     = ARGV[0] if ARGV.size == 1 # user first argument as filename
-options[:sort]   ||= :time # default order
-options[:filter] ||= :all  # default order
+options[:file]        = ARGV[0] if ARGV.size == 1 # user first argument as filename
+options[:sort]        ||= :time # default order
+options[:filter]      ||= :all  # default order
+options[:short_paths] ||= false
 
 LogAnalyzer::Configuration.configure do |config|
   config.filter = options[:filter]
@@ -45,7 +50,7 @@ if options[:file] && options[:sort]
   analyzer = LogAnalyzer.analyze(filename: options[:file])
   analyzer.run
   analyzer.order(by: options[:sort])
-  analyzer.visualize
+  analyzer.visualize(short_paths: options[:short_paths])
 else
   parser.parse! %w[--help]
 end

--- a/lib/log_analyzer.rb
+++ b/lib/log_analyzer.rb
@@ -4,6 +4,7 @@ require "log_analyzer/version"
 require "log_analyzer/configuration"
 require "log_analyzer/stat"
 require "log_analyzer/analyzer"
+require "log_analyzer/path_shortener"
 
 module LogAnalyzer
   def self.analyze(filename:)

--- a/lib/log_analyzer/analyzer.rb
+++ b/lib/log_analyzer/analyzer.rb
@@ -45,7 +45,7 @@ module LogAnalyzer
       end
     end
 
-    def visualize(limit: 100)
+    def visualize(limit: 100, short_paths: false)
       length  = (0..DEFAULT_TABLE_WIDTH - 20).freeze
       filters = LogAnalyzer::Configuration.configuration.filters
       table   = Terminal::Table.new \
@@ -53,9 +53,10 @@ module LogAnalyzer
         width: DEFAULT_TABLE_WIDTH do |t|
           stats.each do |path, stat|
             next unless filters.include?(stat.type)
+            path_to_display = short_paths ? PathShortener.shrink(path, max: length.last) : path[length]
             t.add_row [
               type_label(stat.type),
-              path[length],
+              path_to_display,
               stat.count,
               avg_label(stat.avg),
               stat.max,

--- a/lib/log_analyzer/path_shortener.rb
+++ b/lib/log_analyzer/path_shortener.rb
@@ -1,0 +1,34 @@
+module LogAnalyzer
+  class PathShortener
+    CHARS_TO_IGNORE = %w(.)
+    MAX_LENGTH = 80
+
+    def initialize(path, max: MAX_LENGTH)
+      @path = path
+      @max = max
+    end
+
+    def self.shrink(path, max: MAX_LENGTH)
+      new(path, max: max).shrink
+    end
+
+    def shrink
+      return path if path.length < max
+
+      File.join(
+        File.dirname(path).split(File::SEPARATOR).map { |dir| short_name(dir) },
+        File.basename(path)
+      )
+    end
+
+    private
+
+    attr_reader :path, :max
+
+    def short_name(name)
+      first_char = name[0] || "" # avoid nils in directory names
+
+      CHARS_TO_IGNORE.include?(first_char) ? name[0..1] : first_char
+    end
+  end
+end

--- a/spec/files/file.log
+++ b/spec/files/file.log
@@ -15,6 +15,7 @@ Read fragment views/user-public-venue-info-544-1517258097/uk/6b62fa87d5f3ab11895
   Rendered favorites/_user.html.slim (14.1ms)
   Rendered profile/show.html.slim within layouts/normal (818.8ms)
   Rendered layouts/_title_and_actions.html.slim (0.1ms)
+  Rendered /here/goes/.some/.very/long/path/to/the/some/view/which/also/comes/from/the/gem/gemname/version-0.0.0/app/layouts/_some_partial.html.slim (0.1ms)
   Rendering inline template within layouts/application
   Rendered inline template within layouts/application (4.0ms)
   Rendered shared/_onesignal.html.erb (0.1ms)

--- a/spec/lib/analyzer_spec.rb
+++ b/spec/lib/analyzer_spec.rb
@@ -30,4 +30,9 @@ RSpec.describe LogAnalyzer::Analyzer do
     end
   end
 
+  it "visualizes and shortens the long paths" do
+    analyzer.run
+    expect { analyzer.visualize(short_paths: true) }.not_to raise_error
+  end
+
 end

--- a/spec/lib/path_shortener_spec.rb
+++ b/spec/lib/path_shortener_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe LogAnalyzer::PathShortener do
+  describe "#shrink" do
+    subject { described_class.shrink(path) }
+
+    context "when path lenght is less than max" do
+      let(:path) { "/home/user/.rbenv/versions/file.rb" }
+
+      it { is_expected.to eq path }
+    end
+
+    context "when path lenght is more than max" do
+      let(:path) { "/home/developer/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/actionpack-4.2.8/lib/action_dispatch/middleware/templates/routes/_table.html.erb" }
+      let(:short_path) { "/h/d/.r/v/2/l/r/g/2/g/a/l/a/m/t/r/_table.html.erb" }
+
+      it { is_expected.to eq short_path }
+    end
+  end
+end


### PR DESCRIPTION
Allows to use `--short-paths` options to shrink the long paths.

Some views have a quite long path if they are deep inside some gems. They have their paths truncated which makes not possible to see the file name. 

![screenshot 2018-02-22 10 39 05](https://user-images.githubusercontent.com/123158/36531010-e0f66802-17bc-11e8-9d2c-a08e9e4b9b59.png)

The option shrinks directory names up to a single character which allows seeing the file name of the view.

![screenshot 2018-02-22 10 48 36](https://user-images.githubusercontent.com/123158/36531407-01b524ec-17be-11e8-9e12-0a678968af96.png)

It does not allow users to copy full path, but it does not work for truncated paths either way.
