### PR TITLE
Remove invalid byte sequence on reading

### DIFF
--- a/lib/log_analyzer/analyzer.rb
+++ b/lib/log_analyzer/analyzer.rb
@@ -20,7 +20,7 @@ module LogAnalyzer
 
     def run
       IO.foreach(filename).each do |line|
-        if line =~ MATCHER
+        if line.scrub =~ MATCHER
           if $1 && $2
             view = $1
             @stats[view] ||= Stat.new(type: find_type(view))

--- a/spec/files/file.log
+++ b/spec/files/file.log
@@ -31,3 +31,4 @@ Completed 200 OK in 1000ms (Views: 577.3ms | ActiveRecord: 339.8ms)
   Rendered inline template within layouts/application (56.1ms)
   Rendered shared/_onesignal.html.erb (0.1ms)
   Rendered shared/_fb_recommend.html.erb (0.0ms)
+invalid byte sequence ‹'


### PR DESCRIPTION
Currently, if invalid byte sequence is included in the log file, `ArgumentError` will raise on line match.

Remove invalid byte sequence from the log there is no problem. But it is hard to exclude everything. Therefore, I want to remove that in the analyzer.