### PR TITLE
add a reverse time sorting option

### DIFF
--- a/lib/log_analyzer/analyzer.rb
+++ b/lib/log_analyzer/analyzer.rb
@@ -37,7 +37,7 @@ module LogAnalyzer
       when :time
         @stats = @stats.sort{|a, b| a[1].avg <=> b[1].avg }
       when :rtime
-        @stats = @stats.sort{|a, b| a[1].avg <=> b[1].avg }.reverse
+        @stats = @stats.sort{|a, b| b[1].avg <=> a[1].avg }
       when :count
         @stats = @stats.sort{|a, b| a[1].count <=> b[1].count }
       end

--- a/lib/log_analyzer/analyzer.rb
+++ b/lib/log_analyzer/analyzer.rb
@@ -36,6 +36,8 @@ module LogAnalyzer
         @stats = @stats.sort{|a, b| a[0] <=> b[0] }
       when :time
         @stats = @stats.sort{|a, b| a[1].avg <=> b[1].avg }
+      when :rtime
+        @stats = @stats.sort{|a, b| a[1].avg <=> b[1].avg }.reverse
       when :count
         @stats = @stats.sort{|a, b| a[1].count <=> b[1].count }
       end

--- a/spec/lib/analyzer_spec.rb
+++ b/spec/lib/analyzer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe LogAnalyzer::Analyzer do
   it "sorts" do
     analyzer.run
     expect { analyzer.order(by: :time)  }.not_to raise_error
+    expect { analyzer.order(by: :rtime)  }.not_to raise_error
     expect { analyzer.order(by: :name)  }.not_to raise_error
     expect { analyzer.order(by: :count) }.not_to raise_error
   end


### PR DESCRIPTION
**What?** 
Add 'rtime' sorting option to display the results in descending order.

- [x] Add 'rtime' option
- [x] Add tests

**Screenshot**
![image](https://user-images.githubusercontent.com/26109239/79451631-1eda0900-7fe7-11ea-9eef-702e814896b5.png)
